### PR TITLE
Add list tasks and jobs options

### DIFF
--- a/mule/driver.py
+++ b/mule/driver.py
@@ -5,7 +5,6 @@ import mule.util.yaml.env_var_loader as yaml_util
 from mule.util import JobContext
 from mule.error import messages
 from mule.task import Job
-import os
 from termcolor import cprint
 import sys
 
@@ -13,16 +12,12 @@ def main():
     args = mule.parser.parseArgs()
     try:
         jobs_config, task_configs = validator.getValidatedMuleYaml(args.file)
-        if not args.JOB in jobs_config:
-            raise Exception(messages.JOB_NOT_FOUND.format(args.JOB))
-        job_config = yaml_util.readYamlWithEnvVars(yaml.dump(jobs_config[args.JOB]))
-        job_config.update({
-            'task_configs': task_configs,
-            'name': args.JOB
-        })
-        job = Job(job_config)
-        job_context = JobContext()
-        return job.execute(job_context)
+        if args.list_jobs:
+            _list_jobs(jobs_config)
+        elif args.list_tasks:
+            _list_tasks(task_configs)
+        else:
+            _execute_job(jobs_config, task_configs, args.JOB)
     except Exception as error:
         cprint(
             messages.MULE_DRIVER_EXCEPTION.format(args.JOB, args.file, error),
@@ -31,3 +26,26 @@ def main():
             file = sys.stderr
         )
         raise error
+
+def _list_jobs(jobs_config):
+    for job in jobs_config.keys():
+        print(job)
+
+def _list_tasks(task_configs):
+    for task in task_configs:
+        if 'name' in task.keys():
+            print(f"{task['task']}.{task['name']}")
+        else:
+            print(task['task'])
+
+def _execute_job(jobs_config, task_configs, job):
+    if not job in jobs_config:
+        raise Exception(messages.JOB_NOT_FOUND.format(job))
+    job_config = yaml_util.readYamlWithEnvVars(yaml.dump(jobs_config[job]))
+    job_config.update({
+        'task_configs': task_configs,
+        'name': job
+    })
+    job = Job(job_config)
+    job_context = JobContext()
+    return job.execute(job_context)

--- a/mule/parser.py
+++ b/mule/parser.py
@@ -3,26 +3,45 @@ from mule import __version__
 
 def parseArgs():
     parser = argparse.ArgumentParser(
-        description=f"Script for executing mule (version {__version__})"
+        description=f"Script for executing mule (version {__version__})",
     )
 
     parser.add_argument(
         '-v',
         '--version',
-        action='version',
-        version=__version__
+        action = 'version',
+        version = __version__,
     )
 
     parser.add_argument(
         '-f',
         '--file',
-        default='mule.yaml',
-        help="path to yaml defining mule stages (default: mule.yaml)"
+        default = 'mule.yaml',
+        help = "path to yaml defining mule jobs (default: mule.yaml)",
+    )
+    group = parser.add_mutually_exclusive_group(
+        required=True,
     )
 
-    parser.add_argument(
+    group.add_argument(
+        '--list-jobs',
+        action = 'store_true',
+        dest = 'list_jobs',
+        help = 'lists jobs in mule yaml file',
+    )
+
+    group.add_argument(
+        '--list-tasks',
+        action = 'store_true',
+        dest = 'list_tasks',
+        help = 'lists tasks in mule yaml file',
+    )
+
+    group.add_argument(
         'JOB',
-        help="name of stage you would like to execute"
+        help="name of stage you would like to execute",
+        nargs='?',
+        default = None,
     )
 
     return parser.parse_args()

--- a/mule/parser.py
+++ b/mule/parser.py
@@ -39,7 +39,7 @@ def parseArgs():
 
     group.add_argument(
         'JOB',
-        help="name of stage you would like to execute",
+        help="name of job you would like to execute",
         nargs='?',
         default = None,
     )


### PR DESCRIPTION
This adds mule cli options to list all tasks or jobs in a provided mule yaml file. Below is some sample output

```
➜  mule git:(brice/addListTasksJobsOptions) mule -h
usage: mule [-h] [-v] [-f FILE] (--list-jobs | --list-tasks | JOB)

Script for executing mule (version 0.0.0)

positional arguments:
  JOB                   name of job you would like to execute

optional arguments:
  -h, --help            show this help message and exit
  -v, --version         show program's version number and exit
  -f FILE, --file FILE  path to yaml defining mule jobs (default: mule.yaml)
  --list-jobs           lists jobs in mule yaml file
  --list-tasks          lists tasks in mule yaml file
➜  mule git:(brice/addListTasksJobsOptions) mule -f test/test-yamls/valid/tasks-parameterization-test.yaml --list-tasks    
docker.Version
docker.Version.docker-version-with-name
Echo
Echo.echo-with-name
Echo.multi-level-input
Echo.print-multi-level-input
➜  mule git:(brice/addListTasksJobsOptions) mule -f test/test-yamls/valid/tasks-parameterization-test.yaml --list-jobs     
echo-task-output
echo-with-name-task-output-test
echo-with-name-multi-level-test
echo-configs-override
➜  mule git:(brice/addListTasksJobsOptions) mule -f test/test-yamls/valid/tasks-parameterization-test.yaml echo-task-output
amd64-e7690efb9bb5bb611ee85276382f4e229663c295
```