### PR TITLE
Brice/fix env var evaluation

### DIFF
--- a/mule/task/docker/__init__.py
+++ b/mule/task/docker/__init__.py
@@ -2,6 +2,7 @@ from mule.task import ITask
 import mule.util.docker_util as docker
 from mule.error import messages
 from mule.util import update_dict
+import re
 
 class IDockerTask(ITask):
 
@@ -38,6 +39,8 @@ class IDockerTask(ITask):
                     str,
                     type(env_var)
                 ))
+        dockerEnvVarPattern = re.compile(r'.*=.+')
+        self.docker['env'] = [envVar for envVar in self.docker['env'] if dockerEnvVarPattern.match(envVar)]
 
     def execute(self, job_context):
         super().execute(job_context)

--- a/mule/util/yaml/env_var_loader.py
+++ b/mule/util/yaml/env_var_loader.py
@@ -14,7 +14,8 @@ def path_constructor(loader, node):
             'yellow',
             attrs=['bold']
         )
-    return os.path.expandvars(node.value)
+        return ''
+    return value
 
 def getYamlLoaderWithEnvVars():
     yaml.add_implicit_resolver('!path', env_var_path_matcher)


### PR DESCRIPTION
Now failed env var evaluations will produce an empty string, rather than the bash style env var syntax. Also updated IDockerTask to validate that all env vars are formatted correctly