### PR TITLE
Brice/docker shell config option

### DIFF
--- a/docs/tasks/docker.Make.md
+++ b/docs/tasks/docker.Make.md
@@ -15,6 +15,8 @@ This task executes a make target from within a docker container. This task requi
 
 ## Optional Parameters
 * docker
+  * shell
+    * Shell that will be used in the docker container (`'bash'` by default).
   * workDir
     * Working directory that the task will use inside of the container (`'/project'` by default).
       * The directory that the task is called from will be mounted to this directory on the created container.

--- a/docs/tasks/docker.Shell.md
+++ b/docs/tasks/docker.Shell.md
@@ -15,6 +15,8 @@ This task executes a shell command from within a docker container.
 
 ## Optional Parameters
 * docker
+  * shell
+    * Shell that will be used in the docker container (`'bash'` by default).
   * workDir
     * Working directory that the task will use inside of the container (`'/project'` by default).
       * The directory that the task is called from will be mounted to this directory on the created container.

--- a/mule/task/docker/__init__.py
+++ b/mule/task/docker/__init__.py
@@ -14,6 +14,7 @@ class IDockerTask(ITask):
     optional_typed_fields = [
         ('docker.workDir', str),
         ('docker.env', list),
+        ('docker.shell', str),
     ]
 
     command = ''
@@ -54,11 +55,14 @@ class IDockerTask(ITask):
         dockerVolumePattern = re.compile(r'.+:.+')
         self.docker['volumes'] = [volume for volume in self.docker['volumes'] if dockerVolumePattern.match(volume)]
 
+        if not 'shell' in self.docker.keys():
+            self.docker['shell'] = 'bash'
+
     def execute(self, job_context):
         super().execute(job_context)
         docker.run(
             f"{self.docker['image']}:{self.docker['version']}",
-            ["bash", "-c", self.command],
+            [self.docker['shell'], '-c', self.command],
             self.docker['workDir'],
             self.docker['volumes'],
             self.docker['env'],


### PR DESCRIPTION
This is helpful so that users can use containers that don't come with bash installed (alpine)