### PR TITLE
Remove "outputDir" from download file(s) required fields list

### DIFF
--- a/mule/task/s3/__init__.py
+++ b/mule/task/s3/__init__.py
@@ -44,8 +44,7 @@ class UploadFiles(ITask):
 class DownloadFile(ITask):
     required_fields = [
         'bucketName',
-        'objectName',
-        'outputDir'
+        'objectName'
     ]
 
     def __init__(self, args):


### PR DESCRIPTION
"outputDir" is an optional field that defaults to ".", so I removed it from the `required_fields` list so it can truly be optional.