### PR TITLE
Don't default outputDir to None

### DIFF
--- a/mule/task/s3/__init__.py
+++ b/mule/task/s3/__init__.py
@@ -51,7 +51,7 @@ class DownloadFile(ITask):
         super().__init__(args)
         self.bucketName = args['bucketName']
         self.objectName = args['objectName']
-        self.outputDir = args['outputDir'] if 'outputDir' in args else None
+        self.outputDir = args['outputDir'] if 'outputDir' in args else '.'
         self.fileName = args['fileName'] if 'fileName' in args else None
 
     def download_file(self):
@@ -73,7 +73,7 @@ class DownloadFiles(ITask):
         self.bucketName = args['bucketName']
         self.prefix = args['prefix']
         self.suffix = args['suffix'] if 'suffix' in args else None
-        self.outputDir = args['outputDir'] if 'outputDir' in args else None
+        self.outputDir = args['outputDir'] if 'outputDir' in args else '.'
 
     def download_files(self):
         s3_util.download_files(self.bucketName, self.prefix, self.suffix, self.outputDir)
@@ -100,3 +100,4 @@ class ListFiles(ITask):
     def execute(self, job_context):
         super().execute(job_context)
         self.list_files()
+

--- a/mule/util/s3_util.py
+++ b/mule/util/s3_util.py
@@ -84,7 +84,7 @@ def download_file(bucket_name: str, object_name: str, output_dir: str = ".", fil
     return True
 
 
-def download_files(bucket_name: str, prefix: object = "", suffix: object = "", output_dir: str = "") -> bool:
+def download_files(bucket_name: str, prefix: object = "", suffix: object = "", output_dir: str = ".") -> bool:
     """
     Download Files from S3 bucket.
     :param bucket_name: Name of the S3 bucket.


### PR DESCRIPTION
This will cause an exception b/c a helper method in `download_file` is expecting a string not a None value.