### PR TITLE
Add the ability to provide a prefix (basically a folder) for s3 file uploads

### DIFF
--- a/mule/task/s3/__init__.py
+++ b/mule/task/s3/__init__.py
@@ -27,14 +27,17 @@ class UploadFiles(ITask):
         'bucketName',
         'globSpec'
     ]
+    prefix = None
 
     def __init__(self, args):
         super().__init__(args)
         self.globSpec = args['globSpec']
         self.bucketName = args['bucketName']
+        if 'prefix' in args:
+            self.prefix = args['prefix']
 
     def upload_file(self):
-        s3_util.upload_files(self.globSpec, self.bucketName)
+        s3_util.upload_files(self.globSpec, self.bucketName, self.prefix)
 
     def execute(self, job_context):
         super().execute(job_context)

--- a/mule/util/s3_util.py
+++ b/mule/util/s3_util.py
@@ -21,6 +21,7 @@ def upload_files(globspec: object, bucket_name: str, prefix = None) -> bool:
     Upload files using a list of globs to an S3 bucket.
     :param globspec: Glob to match local files
     :param bucket_name: Bucket name to upload to.
+    :param prefix: Prefix for object names placed in s3
     :return: True if successful, otherwise False.
     """
     response = True

--- a/mule/util/s3_util.py
+++ b/mule/util/s3_util.py
@@ -16,7 +16,7 @@ def _path_leaf(path: str) -> str:
     return tail or ntpath.basename(head)
 
 
-def upload_files(globspec: object, bucket_name: str) -> bool:
+def upload_files(globspec: object, bucket_name: str, prefix = None) -> bool:
     """
     Upload files using a list of globs to an S3 bucket.
     :param globspec: Glob to match local files
@@ -29,9 +29,13 @@ def upload_files(globspec: object, bucket_name: str) -> bool:
     else:
         globspecs = globspec
     for globspec in globspecs:
-        files = glob.glob(globspec)
+        files = glob.glob(globspec, recursive=True)
         for file in files:
-            response &= upload_file(file, bucket_name)
+            file = file.replace('./', '')
+            object_name = file
+            if prefix != None:
+                object_name = f"{prefix}{file}"
+            response &= upload_file(file, bucket_name, object_name)
     return response
 
 

--- a/test/test-yamls/valid/tasks-s3-test.yaml
+++ b/test/test-yamls/valid/tasks-s3-test.yaml
@@ -24,6 +24,13 @@ tasks:
   globSpec:
     - ./*.out
     - ./*.out2
+- task: s3.UploadFiles
+  name: upload_my_files_with_prefix
+  bucketName: algorand-uploads
+  prefix: prefix/
+  globSpec:
+    - '**/*.out'
+    - '**/*.out2'
 jobs:
   s3-list-files:
     tasks:
@@ -40,3 +47,6 @@ jobs:
   s3-upload-files:
     tasks:
       - s3.UploadFiles.upload_my_files
+  s3-upload-files-with-prefix:
+    tasks:
+      - s3.UploadFiles.upload_my_files_with_prefix


### PR DESCRIPTION
This will be necessary for our ci pipeline, and it's a nice addition to the task.