### PR TITLE
Treat "prefix" config as a directory/folder on s3

### DIFF
--- a/mule/task/s3/__init__.py
+++ b/mule/task/s3/__init__.py
@@ -13,9 +13,10 @@ class UploadFile(ITask):
         self.fileName = args['fileName']
         self.bucketName = args['bucketName']
         self.objectName = args['objectName'] if 'objectName' in args else None
+        self.preserveDirs = args['preserveDirs'] if 'preserveDirs' in args else False
 
     def upload_file(self):
-        s3_util.upload_file(self.fileName, self.bucketName, self.objectName)
+        s3_util.upload_file(self.fileName, self.bucketName, self.objectName, self.preserveDirs)
 
     def execute(self, job_context):
         super().execute(job_context)
@@ -27,17 +28,16 @@ class UploadFiles(ITask):
         'bucketName',
         'globSpec'
     ]
-    prefix = None
 
     def __init__(self, args):
         super().__init__(args)
         self.globSpec = args['globSpec']
         self.bucketName = args['bucketName']
-        if 'prefix' in args:
-            self.prefix = args['prefix']
+        self.preserveDirs = args['preserveDirs'] if 'preserveDirs' in args else False
+        self.prefix = args['prefix'] if 'prefix' in args else None
 
     def upload_file(self):
-        s3_util.upload_files(self.globSpec, self.bucketName, self.prefix)
+        s3_util.upload_files(self.globSpec, self.bucketName, self.prefix, self.preserveDirs)
 
     def execute(self, job_context):
         super().execute(job_context)

--- a/mule/util/s3_util.py
+++ b/mule/util/s3_util.py
@@ -34,12 +34,10 @@ def upload_files(globspec: object, bucket_name: str, prefix = None) -> bool:
         files = glob.glob(globspec, recursive=True)
         for file in files:
             if os.path.isfile(file):
-                file = file.replace('./', '')
-                # Remove both "./" from the beginning and "/" from both sides, if present.
-                prefix = prefix.lstrip('.').strip('/')
-                object_name = file
+                object_name = os.path.basename(file)
                 if prefix != None:
-                    object_name = f"{prefix}/{file}"
+                    # Remove both "./" from the beginning and "/" from both sides, if present.
+                    object_name = f"{prefix.lstrip('.').strip('/')}/{object_name}"
                 response &= upload_file(file, bucket_name, object_name)
     return response
 

--- a/mule/util/s3_util.py
+++ b/mule/util/s3_util.py
@@ -35,9 +35,11 @@ def upload_files(globspec: object, bucket_name: str, prefix = None) -> bool:
         for file in files:
             if os.path.isfile(file):
                 file = file.replace('./', '')
+                # Remove both "./" from the beginning and "/" from both sides, if present.
+                prefix = prefix.lstrip('.').strip('/')
                 object_name = file
                 if prefix != None:
-                    object_name = f"{prefix}{file}"
+                    object_name = f"{prefix}/{file}"
                 response &= upload_file(file, bucket_name, object_name)
     return response
 


### PR DESCRIPTION
```
- task: s3.UploadFiles
    name: upload_my_files
    bucketName: ben-test-2.0.3
    prefix: test
    globSpec:
      - ./*.out
```
    
This will upload files to `s3:ben-test-2.0.3/test`, i.e.,
    
    ben-test-2.0.3/test/1.out
    ben-test-2.0.3/test/2.out
    ben-test-2.0.3/test/3.out
    
The current behavior uploads these as:
    
    ben-test-2.0.3/test1.out
    ben-test-2.0.3/test2.out
    ben-test-2.0.3/test3.out
    
I think this is confusing and not what is expected from the "prefix" field.
    
This article treats "prefix" as a synonym of "folder" or "directory":
https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html
