### PR TITLE
Brice/catchup

### DIFF
--- a/mule/task/algorand/node.py
+++ b/mule/task/algorand/node.py
@@ -100,6 +100,24 @@ class Restart(ITask):
         super().execute(job_context)
         algorand_util.restart_node(self.data_dir,  self.kmd_dir, self.bin_dir)
 
+class Status(ITask):
+    required_fields = [
+        'data_dir',
+        'kmd_dir',
+    ]
+    bin_dir = None
+
+    def __init__(self, args):
+        super().__init__(args)
+        self.data_dir = args['data_dir']
+        self.kmd_dir = args['kmd_dir']
+        if 'bin_dir' in args:
+            self.bin_dir = args['bin_dir']
+
+    def execute(self, job_context):
+        super().execute(job_context)
+        algorand_util.status_node(self.data_dir,  self.kmd_dir, self.bin_dir)
+
 class Stop(ITask):
     required_fields = [
         'data_dir',

--- a/mule/task/algorand/node.py
+++ b/mule/task/algorand/node.py
@@ -47,6 +47,23 @@ class Configure(ITask):
             self.kmd_configs
         )
 
+class ShowConfigs(ITask):
+    required_fields = [
+        'data_dir',
+        'kmd_dir',
+    ]
+    def __init__(self, args):
+        super().__init__(args)
+        self.data_dir = args['data_dir']
+        self.kmd_dir = args['kmd_dir']
+
+    def execute(self, job_context):
+        super().execute(job_context)
+        algorand_util.show_node_configs(
+            self.data_dir,
+            self.kmd_dir
+        )
+
 class Start(ITask):
     required_fields = [
         'data_dir',

--- a/mule/task/algorand/node.py
+++ b/mule/task/algorand/node.py
@@ -1,0 +1,85 @@
+from mule.task import ITask
+from mule.util import algorand_util
+
+class Install(ITask):
+    required_fields = [
+        'data_dir',
+        'bin_dir',
+        'channel'
+    ]
+
+    def __init__(self, args):
+        super().__init__(args)
+        self.data_dir = args['data_dir']
+        self.bin_dir = args['bin_dir']
+        self.channel = args['channel']
+
+    def execute(self, job_context):
+        super().execute(job_context)
+        algorand_util.install_node(self.data_dir, self.bin_dir, self.channel)
+
+class Configure(ITask):
+    required_fields = [
+        'data_dir',
+        'kmd_dir',
+    ]
+    algod_port = 60000
+    kmd_port = 60001
+    archival_node = False
+
+    def __init__(self, args):
+        super().__init__(args)
+        self.data_dir = args['data_dir']
+        self.kmd_dir = args['kmd_dir']
+        if 'algod_port' in args:
+            self.algod_port = args['algod_port']
+        if 'kmd_port' in args:
+            self.kmd_port = args['kmd_port']
+        if 'archival_node' in args:
+            self.archival_node = args['archival_node']
+
+    def execute(self, job_context):
+        super().execute(job_context)
+        algorand_util.configure_node(
+            self.data_dir,
+            self.kmd_dir,
+            self.archival_node,
+            self.algod_port,
+            self.kmd_port
+        )
+
+class Start(ITask):
+    required_fields = [
+        'data_dir',
+        'kmd_dir',
+    ]
+    bin_dir = None
+
+    def __init__(self, args):
+        super().__init__(args)
+        self.data_dir = args['data_dir']
+        self.kmd_dir = args['kmd_dir']
+        if 'bin_dir' in args:
+            self.bin_dir = args['bin_dir']
+
+    def execute(self, job_context):
+        super().execute(job_context)
+        algorand_util.start_node(self.data_dir,  self.kmd_dir, self.bin_dir)
+
+class Stop(ITask):
+    required_fields = [
+        'data_dir',
+        'kmd_dir',
+    ]
+    bin_dir = None
+
+    def __init__(self, args):
+        super().__init__(args)
+        self.data_dir = args['data_dir']
+        self.kmd_dir = args['kmd_dir']
+        if 'bin_dir' in args:
+            self.bin_dir = args['bin_dir']
+
+    def execute(self, job_context):
+        super().execute(job_context)
+        algorand_util.stop_node(self.data_dir,  self.kmd_dir, self.bin_dir)

--- a/mule/task/algorand/node.py
+++ b/mule/task/algorand/node.py
@@ -65,6 +65,24 @@ class Start(ITask):
         super().execute(job_context)
         algorand_util.start_node(self.data_dir,  self.kmd_dir, self.bin_dir)
 
+class Restart(ITask):
+    required_fields = [
+        'data_dir',
+        'kmd_dir',
+    ]
+    bin_dir = None
+
+    def __init__(self, args):
+        super().__init__(args)
+        self.data_dir = args['data_dir']
+        self.kmd_dir = args['kmd_dir']
+        if 'bin_dir' in args:
+            self.bin_dir = args['bin_dir']
+
+    def execute(self, job_context):
+        super().execute(job_context)
+        algorand_util.restart_node(self.data_dir,  self.kmd_dir, self.bin_dir)
+
 class Stop(ITask):
     required_fields = [
         'data_dir',

--- a/mule/task/algorand/node.py
+++ b/mule/task/algorand/node.py
@@ -27,29 +27,24 @@ class Configure(ITask):
         'data_dir',
         'kmd_dir',
     ]
-    algod_port = 60000
-    kmd_port = 60001
-    archival_node = False
-
+    node_configs = {}
+    kmd_configs = {}
     def __init__(self, args):
         super().__init__(args)
         self.data_dir = args['data_dir']
         self.kmd_dir = args['kmd_dir']
-        if 'algod_port' in args:
-            self.algod_port = args['algod_port']
-        if 'kmd_port' in args:
-            self.kmd_port = args['kmd_port']
-        if 'archival_node' in args:
-            self.archival_node = args['archival_node']
+        if 'node_configs' in args:
+            self.node_configs = args['node_configs']
+        if 'kmd_configs' in args:
+            self.kmd_configs = args['kmd_configs']
 
     def execute(self, job_context):
         super().execute(job_context)
         algorand_util.configure_node(
             self.data_dir,
             self.kmd_dir,
-            self.archival_node,
-            self.algod_port,
-            self.kmd_port
+            self.node_configs,
+            self.kmd_configs
         )
 
 class Start(ITask):

--- a/mule/task/algorand/node.py
+++ b/mule/task/algorand/node.py
@@ -7,6 +7,7 @@ class Install(ITask):
         'bin_dir',
         'channel'
     ]
+    version = 'latest'
 
     def __init__(self, args):
         super().__init__(args)
@@ -14,9 +15,12 @@ class Install(ITask):
         self.bin_dir = args['bin_dir']
         self.channel = args['channel']
 
+        if 'version' in args:
+            self.version = args['version']
+
     def execute(self, job_context):
         super().execute(job_context)
-        algorand_util.install_node(self.data_dir, self.bin_dir, self.channel)
+        algorand_util.install_node(self.data_dir, self.bin_dir, self.channel, self.version)
 
 class Configure(ITask):
     required_fields = [

--- a/mule/util/algorand_util.py
+++ b/mule/util/algorand_util.py
@@ -76,8 +76,8 @@ def configure_node(data_dir, kmd_dir, node_config, kmd_config):
     file_util.ensure_file(node_config_path, '{}')
     file_util.ensure_file(kmd_config_path, '{}')
 
-    current_node_config = file_util.readJsonFile(node_config_path)
-    current_kmd_config = file_util.readJsonFile(kmd_config_path)
+    current_node_config = file_util.read_json_file(node_config_path)
+    current_kmd_config = file_util.read_json_file(kmd_config_path)
 
     current_node_config.update(node_config)
     current_kmd_config.update(kmd_config)
@@ -85,8 +85,8 @@ def configure_node(data_dir, kmd_dir, node_config, kmd_config):
     print(f"Updating node configs at {node_config_path} with:\n{json.dumps(node_config, sort_keys=True, indent=4)}")
     print(f"Updating node configs at {kmd_config_path} with:\n{json.dumps(kmd_config, sort_keys=True, indent=4)}")
 
-    file_util.writeJsonFile(node_config_path, current_node_config)
-    file_util.writeJsonFile(kmd_config_path, current_kmd_config)
+    file_util.write_json_file(node_config_path, current_node_config)
+    file_util.write_json_file(kmd_config_path, current_kmd_config)
 
 def start_node(data_dir, kmd_dir, bin_dir=None):
     goal_args = [

--- a/mule/util/algorand_util.py
+++ b/mule/util/algorand_util.py
@@ -15,13 +15,15 @@ def build_algo_release_url(package_type, channel, os_type, cpu_arch_type, packag
 def get_latest_package_version(package_type, channel, os_type, cpu_arch_type):
     os_type = os_util.get_os_type()
     cpu_arch_type = os_util.get_cpu_arch_type()
-    package_keys = s3_util.list_keys(
+    package_keys = list(s3_util.get_matching_s3_keys(
         'algorand-releases',
         f"channel/{channel}/{package_type}_{channel}_{os_type}-{cpu_arch_type}_",
         'tar.gz'
-    )
+    ))
     package_versions = list(map(semver_util.parse_version, package_keys))
-    return semver_util.get_highest_version(package_versions)
+    latest_version = semver_util.get_highest_version(package_versions)
+    print(f"Found latest version of package type {package_type} for channel {channel}: {latest_version}")
+    return latest_version
 
 def install_node(data_dir, bin_dir, channel, node_package_version='latest'):
     """
@@ -40,6 +42,8 @@ def install_node(data_dir, bin_dir, channel, node_package_version='latest'):
         else:
             node_package_version = get_latest_package_version('node', channel, os_type, cpu_arch_type)
 
+    print(f"Installing {channel} node package version {node_package_version} to:\n\tbin_dir: {bin_dir}\n\tdata_dir: {data_dir}")
+
     node_package_url = build_algo_release_url('node', channel, os_type, cpu_arch_type, node_package_version)
     if channel == 'test':
         node_package_url = build_algo_release_url('node', 'stable', os_type, cpu_arch_type, node_package_version)
@@ -49,11 +53,15 @@ def install_node(data_dir, bin_dir, channel, node_package_version='latest'):
     file_util.decompressTarfile(node_package_tar_path, f"{node_package_dir}")
 
     file_util.mv_folder_contents(f"{node_package_dir}/data", data_dir)
-    file_util.mv_folder_contents(f"{node_package_dir}/genesis", data_dir, ignore=True)
     file_util.mv_folder_contents(f"{node_package_dir}/bin", bin_dir)
-    if not channel == 'stable':
+    if channel == 'stable':
         file_util.mv_file(
-            os.path.join(data_dir, f"{channel}net/genesis.json"),
+            os.path.join(node_package_dir, "genesis/mainnet/genesis.json"),
+            os.path.join(data_dir, 'genesis.json')
+        )
+    else:
+        file_util.mv_file(
+            os.path.join(node_package_dir, f"genesis/{channel}net/genesis.json"),
             os.path.join(data_dir, 'genesis.json')
         )
 
@@ -73,6 +81,9 @@ def configure_node(data_dir, kmd_dir, node_config, kmd_config):
     current_node_config.update(node_config)
     current_kmd_config.update(kmd_config)
 
+    print(f"Updating node configs at {node_config_path} with:\n{json.dumps(node_config, sort_keys=True, indent=4)}")
+    print(f"Updating node configs at {kmd_config_path} with:\n{json.dumps(kmd_config, sort_keys=True, indent=4)}")
+
     file_util.writeJsonFile(node_config_path, current_node_config)
     file_util.writeJsonFile(kmd_config_path, current_kmd_config)
 
@@ -81,6 +92,7 @@ def start_node(data_dir, kmd_dir, bin_dir=None):
         'node',
         'start',
     ]
+    print(f"Starting node with:\n\tdata_dir: {data_dir}\n\tkmd_dir: {kmd_dir}")
     goal(data_dir, kmd_dir, goal_args, bin_dir)
 
 def stop_node(data_dir, kmd_dir, bin_dir=None):
@@ -88,6 +100,7 @@ def stop_node(data_dir, kmd_dir, bin_dir=None):
         'node',
         'stop',
     ]
+    print(f"Stopping node with:\n\tdata_dir: {data_dir}\n\tkmd_dir: {kmd_dir}")
     goal(data_dir, kmd_dir, goal_args, bin_dir)
 
 def goal(data_dir, kmd_dir, args, bin_dir=None):

--- a/mule/util/algorand_util.py
+++ b/mule/util/algorand_util.py
@@ -104,6 +104,14 @@ def stop_node(data_dir, kmd_dir, bin_dir=None):
     print(f"Stopping node with:\n\tdata_dir: {data_dir}\n\tkmd_dir: {kmd_dir}")
     goal(data_dir, kmd_dir, goal_args, bin_dir)
 
+def restart_node(data_dir, kmd_dir, bin_dir=None):
+    goal_args = [
+        'node',
+        'restart',
+    ]
+    print(f"Restarting node with:\n\tdata_dir: {data_dir}\n\tkmd_dir: {kmd_dir}")
+    goal(data_dir, kmd_dir, goal_args, bin_dir)
+
 def goal(data_dir, kmd_dir, args, bin_dir=None):
     goal_command = ['goal']
     if not bin_dir is None:

--- a/mule/util/algorand_util.py
+++ b/mule/util/algorand_util.py
@@ -66,6 +66,21 @@ def install_node(data_dir, bin_dir, channel, node_package_version='latest'):
             os.path.join(data_dir, 'genesis.json')
         )
 
+def show_node_configs(data_dir, kmd_dir):
+    data_dir = file_util.ensure_folder(data_dir)
+    kmd_dir = file_util.ensure_folder(kmd_dir)
+    node_config_path = f"{data_dir}/config.json"
+    kmd_config_path = f"{kmd_dir}/kmd_config.json"
+
+    file_util.ensure_file(node_config_path, '{}')
+    file_util.ensure_file(kmd_config_path, '{}')
+
+    current_node_config = file_util.read_json_file(node_config_path)
+    current_kmd_config = file_util.read_json_file(kmd_config_path)
+
+    print(f"Showing node configs at {node_config_path} with:\n{json.dumps(current_node_config, sort_keys=True, indent=4)}")
+    print(f"Showing node configs at {kmd_config_path} with:\n{json.dumps(current_kmd_config, sort_keys=True, indent=4)}")
+
 def configure_node(data_dir, kmd_dir, node_config, kmd_config):
 
     data_dir = file_util.ensure_folder(data_dir)

--- a/mule/util/algorand_util.py
+++ b/mule/util/algorand_util.py
@@ -18,7 +18,8 @@ def get_latest_package_version(package_type, channel, os_type, cpu_arch_type):
     package_keys = list(s3_util.get_matching_s3_keys(
         'algorand-releases',
         f"channel/{channel}/{package_type}_{channel}_{os_type}-{cpu_arch_type}_",
-        'tar.gz'
+        'tar.gz',
+        s3_auth=False
     ))
     package_versions = list(map(semver_util.parse_version, package_keys))
     latest_version = semver_util.get_highest_version(package_versions)

--- a/mule/util/algorand_util.py
+++ b/mule/util/algorand_util.py
@@ -127,6 +127,14 @@ def restart_node(data_dir, kmd_dir, bin_dir=None):
     print(f"Restarting node with:\n\tdata_dir: {data_dir}\n\tkmd_dir: {kmd_dir}")
     goal(data_dir, kmd_dir, goal_args, bin_dir)
 
+def status_node(data_dir, kmd_dir, bin_dir=None):
+    goal_args = [
+        'node',
+        'status',
+    ]
+    print(f"Status of node with:\n\tdata_dir: {data_dir}\n\tkmd_dir: {kmd_dir}")
+    goal(data_dir, kmd_dir, goal_args, bin_dir)
+
 def goal(data_dir, kmd_dir, args, bin_dir=None):
     goal_command = ['goal']
     if not bin_dir is None:

--- a/mule/util/algorand_util.py
+++ b/mule/util/algorand_util.py
@@ -56,12 +56,12 @@ def install_node(data_dir, bin_dir, channel, node_package_version='latest'):
     file_util.mv_folder_contents(f"{node_package_dir}/data", data_dir)
     file_util.mv_folder_contents(f"{node_package_dir}/bin", bin_dir)
     if channel == 'stable':
-        file_util.mv_file(
+        file_util.copy_file(
             os.path.join(node_package_dir, "genesis/mainnet/genesis.json"),
             os.path.join(data_dir, 'genesis.json')
         )
     else:
-        file_util.mv_file(
+        file_util.copy_file(
             os.path.join(node_package_dir, f"genesis/{channel}net/genesis.json"),
             os.path.join(data_dir, 'genesis.json')
         )

--- a/mule/util/algorand_util.py
+++ b/mule/util/algorand_util.py
@@ -4,42 +4,81 @@ import json
 import urllib.request
 from mule.util import os_util
 from mule.util import file_util
+from mule.util import time_util
+from mule.util import s3_util
+from mule.util import semver_util
 import platform
 
-def install_node(data_dir, bin_dir, channel, installer_version='2.0.4'):
+def build_algo_release_url(package_type, channel, os_type, cpu_arch_type, package_version):
+    return f"https://algorand-releases.s3.amazonaws.com/channel/{channel}/{package_type}_{channel}_{os_type}-{cpu_arch_type}_{package_version}.tar.gz"
+
+def get_latest_package_version(package_type, channel, os_type, cpu_arch_type):
+    os_type = os_util.get_os_type()
+    cpu_arch_type = os_util.get_cpu_arch_type()
+    package_keys = s3_util.list_keys(
+        'algorand-releases',
+        f"channel/{channel}/{package_type}_{channel}_{os_type}-{cpu_arch_type}_",
+        'tar.gz'
+    )
+    package_versions = list(map(semver_util.parse_version, package_keys))
+    return semver_util.get_highest_version(package_versions)
+
+def install_node(data_dir, bin_dir, channel, node_package_version='latest'):
     """
     Download and install algod.
     """
-    installer_dir = '/tmp/algod-inst'
-    os.makedirs(installer_dir, exist_ok=True)
+    node_package_dir = file_util.ensure_folder(f"/tmp/algod-pkg-{time_util.get_timestamp()}")
+    data_dir = file_util.ensure_folder(data_dir)
+    bin_dir = file_util.ensure_folder(bin_dir)
 
     os_type = os_util.get_os_type()
     cpu_arch_type = os_util.get_cpu_arch_type()
 
-    installer_url = f"https://algorand-releases.s3.amazonaws.com/channel/stable/install_stable_{os_type}-{cpu_arch_type}_{installer_version}.tar.gz"
-    installer_tar_path = f"{installer_dir}/installer.tar.gz"
+    if node_package_version == 'latest':
+        if channel == 'test':
+            node_package_version = get_latest_package_version('node', 'stable', os_type, cpu_arch_type)
+        else:
+            node_package_version = get_latest_package_version('node', channel, os_type, cpu_arch_type)
 
-    _ = urllib.request.urlretrieve(installer_url, installer_tar_path)
-    file_util.decompressTarfile(installer_tar_path, f"{installer_dir}")
+    node_package_url = build_algo_release_url('node', channel, os_type, cpu_arch_type, node_package_version)
+    if channel == 'test':
+        node_package_url = build_algo_release_url('node', 'stable', os_type, cpu_arch_type, node_package_version)
+    node_package_tar_path = f"{node_package_dir}/node_package.tar.gz"
 
-    installer_command = [f"{installer_dir}/update.sh", '-i', '-n']
-    installer_command.extend(['-c', channel])
-    installer_command.extend(['-p', bin_dir])
-    installer_command.extend(['-d', data_dir])
+    _ = urllib.request.urlretrieve(node_package_url, node_package_tar_path)
+    file_util.decompressTarfile(node_package_tar_path, f"{node_package_dir}")
 
-    subprocess.run(installer_command, check=True)
+    file_util.mv_folder_contents(f"{node_package_dir}/data", data_dir)
+    file_util.mv_folder_contents(f"{node_package_dir}/genesis", data_dir, ignore=True)
+    file_util.mv_folder_contents(f"{node_package_dir}/bin", bin_dir)
+    if not channel == 'stable':
+        file_util.mv_file(
+            os.path.join(data_dir, f"{channel}net/genesis.json"),
+            os.path.join(data_dir, 'genesis.json')
+        )
 
 def configure_node(data_dir, kmd_dir, archival_node=False, algod_port=60000, kmd_port=60001):
-    node_configs = {
-        'EndpointAddress': f"0.0.0.0:{algod_port}",
-        'Archival': archival_node
-    }
-    kmd_configs = {
-        'address': f"0.0.0.0:{kmd_port}"
-    }
 
-    file_util.writeJsonFile(f"{data_dir}/config.json", node_configs)
-    file_util.writeJsonFile(f"{kmd_dir}/kmd_config.json", kmd_configs)
+    data_dir = file_util.ensure_folder(data_dir)
+    kmd_dir = file_util.ensure_folder(kmd_dir)
+    node_config_path = f"{data_dir}/config.json"
+    kmd_config_path = f"{kmd_dir}/kmd_config.json"
+
+    file_util.ensure_file(node_config_path, '{}')
+    file_util.ensure_file(kmd_config_path, '{}')
+
+    node_config = file_util.readJsonFile(node_config_path)
+    kmd_config = file_util.readJsonFile(kmd_config_path)
+
+    node_config['EndpointAddress'] = f"0.0.0.0:{algod_port}"
+    node_config['Archival'] = archival_node
+    if 'beta' in data_dir:
+        node_config['DNSBootstrapID'] = '<network>.algodev.network'
+
+    kmd_config['address'] = f"0.0.0.0:{kmd_port}"
+
+    file_util.writeJsonFile(node_config_path, node_config)
+    file_util.writeJsonFile(kmd_config_path, kmd_config)
 
 def start_node(data_dir, kmd_dir, bin_dir=None):
     goal_args = [

--- a/mule/util/algorand_util.py
+++ b/mule/util/algorand_util.py
@@ -1,0 +1,69 @@
+import os
+import subprocess
+import json
+import urllib.request
+from mule.util import os_util
+from mule.util import file_util
+import platform
+
+def install_node(data_dir, bin_dir, channel, installer_version='2.0.4'):
+    """
+    Download and install algod.
+    """
+    installer_dir = '/tmp/algod-inst'
+    os.makedirs(installer_dir, exist_ok=True)
+
+    os_type = os_util.get_os_type()
+    cpu_arch_type = os_util.get_cpu_arch_type()
+
+    installer_url = f"https://algorand-releases.s3.amazonaws.com/channel/stable/install_stable_{os_type}-{cpu_arch_type}_{installer_version}.tar.gz"
+    installer_tar_path = f"{installer_dir}/installer.tar.gz"
+
+    _ = urllib.request.urlretrieve(installer_url, installer_tar_path)
+    file_util.decompressTarfile(installer_tar_path, f"{installer_dir}")
+
+    installer_command = [f"{installer_dir}/update.sh", '-i', '-n']
+    installer_command.extend(['-c', channel])
+    installer_command.extend(['-p', bin_dir])
+    installer_command.extend(['-d', data_dir])
+
+    subprocess.run(installer_command, check=True)
+
+def configure_node(data_dir, kmd_dir, archival_node=False, algod_port=60000, kmd_port=60001):
+    node_configs = {
+        'EndpointAddress': f"0.0.0.0:{algod_port}",
+        'Archival': archival_node
+    }
+    kmd_configs = {
+        'address': f"0.0.0.0:{kmd_port}"
+    }
+
+    file_util.writeJsonFile(f"{data_dir}/config.json", node_configs)
+    file_util.writeJsonFile(f"{kmd_dir}/kmd_config.json", kmd_configs)
+
+def start_node(data_dir, kmd_dir, bin_dir=None):
+    goal_args = [
+        'node',
+        'start',
+    ]
+    goal(data_dir, kmd_dir, goal_args, bin_dir)
+
+def stop_node(data_dir, kmd_dir, bin_dir=None):
+    goal_args = [
+        'node',
+        'stop',
+    ]
+    goal(data_dir, kmd_dir, goal_args, bin_dir)
+
+def goal(data_dir, kmd_dir, args, bin_dir=None):
+    goal_command = ['goal']
+    if not bin_dir is None:
+        goal_command = [f"{bin_dir}/goal"]
+
+    goal_command.extend([
+        '-d', data_dir,
+        '-k', kmd_dir,
+    ])
+    goal_command.extend(args)
+
+    subprocess.run(goal_command, check=True)

--- a/mule/util/algorand_util.py
+++ b/mule/util/algorand_util.py
@@ -57,7 +57,7 @@ def install_node(data_dir, bin_dir, channel, node_package_version='latest'):
             os.path.join(data_dir, 'genesis.json')
         )
 
-def configure_node(data_dir, kmd_dir, archival_node=False, algod_port=60000, kmd_port=60001):
+def configure_node(data_dir, kmd_dir, node_config, kmd_config):
 
     data_dir = file_util.ensure_folder(data_dir)
     kmd_dir = file_util.ensure_folder(kmd_dir)
@@ -67,18 +67,14 @@ def configure_node(data_dir, kmd_dir, archival_node=False, algod_port=60000, kmd
     file_util.ensure_file(node_config_path, '{}')
     file_util.ensure_file(kmd_config_path, '{}')
 
-    node_config = file_util.readJsonFile(node_config_path)
-    kmd_config = file_util.readJsonFile(kmd_config_path)
+    current_node_config = file_util.readJsonFile(node_config_path)
+    current_kmd_config = file_util.readJsonFile(kmd_config_path)
 
-    node_config['EndpointAddress'] = f"0.0.0.0:{algod_port}"
-    node_config['Archival'] = archival_node
-    if 'beta' in data_dir:
-        node_config['DNSBootstrapID'] = '<network>.algodev.network'
+    current_node_config.update(node_config)
+    current_kmd_config.update(kmd_config)
 
-    kmd_config['address'] = f"0.0.0.0:{kmd_port}"
-
-    file_util.writeJsonFile(node_config_path, node_config)
-    file_util.writeJsonFile(kmd_config_path, kmd_config)
+    file_util.writeJsonFile(node_config_path, current_node_config)
+    file_util.writeJsonFile(kmd_config_path, current_kmd_config)
 
 def start_node(data_dir, kmd_dir, bin_dir=None):
     goal_args = [

--- a/mule/util/file_util.py
+++ b/mule/util/file_util.py
@@ -65,5 +65,5 @@ def mv_folder_contents(source, dest, ignore=False):
             if not ignore:
                 raise
 
-def mv_file(source, dest):
-    shutil.move(source, dest)
+def copy_file(source, dest):
+    shutil.copy(source, dest)

--- a/mule/util/file_util.py
+++ b/mule/util/file_util.py
@@ -3,6 +3,7 @@ import yaml
 from glob import glob
 import tarfile
 import json
+import shutil
 
 def deleteFile(path):
     os.remove(path)
@@ -35,6 +36,34 @@ def decompressTarfile(file_name, target_directory = '.'):
     with tarfile.open(file_name, "r:gz") as tar:
         tar.extractall(target_directory)
 
+def readJsonFile(file_name):
+    with open(file_name, 'r') as json_file:
+        return json.load(json_file)
+
 def writeJsonFile(file_name, contents):
     with open(file_name, 'w') as json_file:
         json.dump(contents, json_file)
+
+def ensure_file(file_name, contents=None):
+    if not os.path.exists(file_name):
+        with open(file_name, 'w') as file:
+            if contents is None:
+                pass
+            file.write(contents)
+
+def ensure_folder(folder_name):
+    folder_name = folder_name.replace('~', os.path.expanduser('~'))
+    os.makedirs(folder_name, exist_ok=True)
+    return folder_name
+
+def mv_folder_contents(source, dest, ignore=False):
+    files = os.listdir(source)
+    for file in files:
+        try:
+            shutil.move(os.path.join(source, file), os.path.join(dest, file))
+        except:
+            if not ignore:
+                raise
+
+def mv_file(source, dest):
+    shutil.move(source, dest)

--- a/mule/util/file_util.py
+++ b/mule/util/file_util.py
@@ -2,6 +2,7 @@ import os
 import yaml
 from glob import glob
 import tarfile
+import json
 
 def deleteFile(path):
     os.remove(path)
@@ -33,3 +34,7 @@ def compressFiles(file_name, globspecs):
 def decompressTarfile(file_name, target_directory = '.'):
     with tarfile.open(file_name, "r:gz") as tar:
         tar.extractall(target_directory)
+
+def writeJsonFile(file_name, contents):
+    with open(file_name, 'w') as json_file:
+        json.dump(contents, json_file)

--- a/mule/util/file_util.py
+++ b/mule/util/file_util.py
@@ -36,11 +36,11 @@ def decompressTarfile(file_name, target_directory = '.'):
     with tarfile.open(file_name, "r:gz") as tar:
         tar.extractall(target_directory)
 
-def readJsonFile(file_name):
+def read_json_file(file_name):
     with open(file_name, 'r') as json_file:
         return json.load(json_file)
 
-def writeJsonFile(file_name, contents):
+def write_json_file(file_name, contents):
     with open(file_name, 'w') as json_file:
         json.dump(contents, json_file)
 

--- a/mule/util/os_util.py
+++ b/mule/util/os_util.py
@@ -1,0 +1,16 @@
+import platform
+
+def get_os_type():
+    return platform.system().lower()
+
+def get_cpu_arch_type():
+    arch = platform.machine()
+    if arch == "x86_64":
+        return "amd64"
+    elif arch == "armv6l":
+        return "arm"
+    elif arch == "armv7l":
+        return "arm"
+    elif arch == "aarch64":
+        return "arm64"
+    return "unknown"

--- a/mule/util/s3_util.py
+++ b/mule/util/s3_util.py
@@ -1,11 +1,17 @@
 import logging
 import boto3
+from botocore import UNSIGNED
+from botocore.client import Config
 from botocore.exceptions import ClientError
 import ntpath
 import os.path
 import glob
 import os
 
+def get_s3_client(auth=True):
+    if not auth:
+        return boto3.client('s3', config=Config(signature_version=UNSIGNED))
+    return boto3.client('s3')
 
 def _path_leaf(path: str) -> str:
     """
@@ -62,7 +68,7 @@ def upload_file(file_name: str, bucket_name: str, object_name=None, preserveDirs
         # If S3 object_name was not specified, use file_name
         if object_name is None:
             object_name = _get_object_name(file_name, preserveDirs)
-        s3_client = boto3.client('s3')
+        s3_client = get_s3_client()
         # Upload the file
         print("uploading file '{}' to bucket '{}' to object '{}'".format(file_name, bucket_name, object_name))
         response = s3_client.upload_file(file_name, bucket_name, object_name)
@@ -74,7 +80,7 @@ def upload_file(file_name: str, bucket_name: str, object_name=None, preserveDirs
     return True
 
 
-def download_file(bucket_name: str, object_name: str, output_dir: str = ".", file_name: str = None) -> bool:
+def download_file(bucket_name: str, object_name: str, output_dir: str = ".", file_name: str = None, s3_auth = True) -> bool:
     """
     Download a file from an S3 bucket.
     :param bucket_name: Name of the S3 bucket.
@@ -89,7 +95,7 @@ def download_file(bucket_name: str, object_name: str, output_dir: str = ".", fil
         else:
             file_path = os.path.join(output_dir, file_name)
         print("downloading object '{}' from bucket '{}' to file '{}'".format(object_name, bucket_name, file_path))
-        s3_client = boto3.client('s3')
+        s3_client = get_s3_client(s3_auth)
         response = s3_client.download_file(bucket_name, object_name, file_path)
         if response is not None:
             print(response)
@@ -99,7 +105,7 @@ def download_file(bucket_name: str, object_name: str, output_dir: str = ".", fil
     return True
 
 
-def download_files(bucket_name: str, prefix: object = "", suffix: object = "", output_dir: str = ".") -> bool:
+def download_files(bucket_name: str, prefix: object = "", suffix: object = "", output_dir: str = ".", s3_auth = True) -> bool:
     """
     Download Files from S3 bucket.
     :param bucket_name: Name of the S3 bucket.
@@ -109,13 +115,13 @@ def download_files(bucket_name: str, prefix: object = "", suffix: object = "", o
     :return: True if successful, otherwise False.
     """
     result = True
-    for key in get_matching_s3_keys(bucket_name, prefix, suffix):
-        result &= download_file(bucket_name, key, output_dir)
+    for key in get_matching_s3_keys(bucket_name, prefix, suffix, s3_auth=s3_auth):
+        result &= download_file(bucket_name, key, output_dir, s3_auth=s3_auth)
     return result
 
 
-def get_bucket_keys(bucket_name: str, prefix: object = "", suffix: object = ""):
-    objects = boto3.client('s3').list_objects_v2(Bucket=bucket_name, Prefix=prefix)
+def get_bucket_keys(bucket_name: str, prefix: object = "", suffix: object = "", s3_auth = True):
+    objects = get_s3_client(s3_auth).list_objects_v2(Bucket=bucket_name, Prefix=prefix)
     return [ obj['Key'] for obj in objects['Contents'] ]
 
 
@@ -130,33 +136,30 @@ def copy_bucket_object(source_bucket: str, source_key: str, dest_bucket: str, de
     s3_client.meta.client.copy(copy_source, dest_bucket, dest_key + '/' + filename)
 
 
-def list_keys(bucket_name: str, prefix: object = "", suffix: object = ""):
+def list_keys(bucket_name: str, prefix: object = "", suffix: object = "", s3_auth = True):
     """
     Print keys in S3 bucket.
     :param bucket_name: Name of the S3 bucket.
     :param prefix: List keys whose key starts with this prefix (optional).
     :param suffix: List keys whose keys end with this suffix (optional).
     """
-    matching_keys = []
-    for key in get_matching_s3_keys(bucket_name, prefix, suffix):
-        matching_keys.append(key)
+    for key in get_matching_s3_keys(bucket_name, prefix, suffix, s3_auth=s3_auth):
         print(key)
-    return matching_keys
 
 
-def list_objects(bucket_name: str, prefix: object = "", suffix: object = ""):
+def list_objects(bucket_name: str, prefix: object = "", suffix: object = "", s3_auth = True):
     """
     Print objects in S3 bucket.
     :param bucket_name: Name of the S3 bucket.
     :param prefix: List objects whose key starts with this prefix (optional).
     :param suffix: List objects whose keys end with this suffix (optional).
     """
-    for obj in get_matching_s3_objects(bucket_name, prefix, suffix):
+    for obj in get_matching_s3_objects(bucket_name, prefix, suffix, s3_auth=s3_auth):
         print(obj)
 
 
 # based on https://alexwlchan.net/2019/07/listing-s3-keys/
-def get_matching_s3_objects(bucket: str, prefix: object = "", suffix: object = ""):
+def get_matching_s3_objects(bucket: str, prefix: object = "", suffix: object = "", s3_auth = True):
     """
     Generate objects in an S3 bucket.
     :param bucket: Name of the S3 bucket.
@@ -165,7 +168,7 @@ def get_matching_s3_objects(bucket: str, prefix: object = "", suffix: object = "
     :param suffix: Only fetch objects whose keys end with
         this suffix (optional).
     """
-    s3 = boto3.client("s3")
+    s3 = get_s3_client(s3_auth)
     paginator = s3.get_paginator("list_objects_v2")
 
     kwargs = {'Bucket': bucket}
@@ -197,12 +200,12 @@ def get_matching_s3_objects(bucket: str, prefix: object = "", suffix: object = "
                     yield obj
 
 
-def get_matching_s3_keys(bucket: str, prefix: object = "", suffix: object = ""):
+def get_matching_s3_keys(bucket: str, prefix: object = "", suffix: object = "", s3_auth = True):
     """
     Generate the keys in an S3 bucket.
     :param bucket: Name of the S3 bucket.
     :param prefix: Only fetch keys that start with this prefix (optional).
     :param suffix: Only fetch keys that end with this suffix (optional).
     """
-    for obj in get_matching_s3_objects(bucket, prefix, suffix):
+    for obj in get_matching_s3_objects(bucket, prefix, suffix, s3_auth=s3_auth):
         yield obj["Key"]

--- a/mule/util/s3_util.py
+++ b/mule/util/s3_util.py
@@ -137,8 +137,11 @@ def list_keys(bucket_name: str, prefix: object = "", suffix: object = ""):
     :param prefix: List keys whose key starts with this prefix (optional).
     :param suffix: List keys whose keys end with this suffix (optional).
     """
-    for keys in get_matching_s3_keys(bucket_name, prefix, suffix):
-        print(keys)
+    matching_keys = []
+    for key in get_matching_s3_keys(bucket_name, prefix, suffix):
+        matching_keys.append(key)
+        print(key)
+    return matching_keys
 
 
 def list_objects(bucket_name: str, prefix: object = "", suffix: object = ""):

--- a/mule/util/semver_util.py
+++ b/mule/util/semver_util.py
@@ -1,0 +1,15 @@
+from packaging import version
+import re
+
+def get_highest_version(semver_version_strings):
+    semver_versions = list(
+        map(
+            lambda semver_version_string: version.parse(semver_version_string),
+            semver_version_strings
+        )
+    )
+    return max(semver_versions)
+
+def parse_version(string):
+    version_re = re.compile(r'(\d*)\.(\d*)\.(\d*)')
+    return re.search(version_re, string).group(0)

--- a/mule/util/semver_util.py
+++ b/mule/util/semver_util.py
@@ -8,7 +8,7 @@ def get_highest_version(semver_version_strings):
             semver_version_strings
         )
     )
-    return max(semver_versions)
+    return str(max(semver_versions))
 
 def parse_version(string):
     version_re = re.compile(r'(\d*)\.(\d*)\.(\d*)')

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setuptools.setup(
         'pyyaml',
         'termcolor',
         'boto3',
-        'botocore'
+        'botocore',
+        'packaging'
     ],
     license='MIT',
     classifiers=[

--- a/test/test-yamls/valid/algorand-test.yaml
+++ b/test/test-yamls/valid/algorand-test.yaml
@@ -15,7 +15,7 @@ tasks:
   name: test
   data_dir: /etc/algorand/node_dirs/node/test/latest/data
   bin_dir: /etc/algorand/node_dirs/node/test/latest/bin
-  channel: stable
+  channel: test
   version: latest
 - task: shell.shell
   command: /etc/algorand/node_dirs/node/test/latest/data/genesis

--- a/test/test-yamls/valid/algorand-test.yaml
+++ b/test/test-yamls/valid/algorand-test.yaml
@@ -24,23 +24,30 @@ tasks:
   name: stable
   data_dir: /etc/algorand/node_dirs/node/stable/latest/data
   kmd_dir: /etc/algorand/node_dirs/node/stable/latest/kmd
-  algod_port: 60000
-  kmd_port: 60001
-  archival_node: true
+  node_configs:
+    EndpointAddress: 0.0.0.0:60000
+    Archival: true
+  kmd_configs:
+    address: 0.0.0.0:60001
 - task: algorand.node.Configure
   name: beta
   data_dir: /etc/algorand/node_dirs/node/beta/latest/data
   kmd_dir: /etc/algorand/node_dirs/node/beta/latest/kmd
-  algod_port: 60002
-  kmd_port: 60003
-  archival_node: true
+  node_configs:
+    EndpointAddress: 0.0.0.0:60002
+    Archival: true
+    DNSBootstrapID: <network>.algodev.network
+  kmd_configs:
+    address: 0.0.0.0:60003
 - task: algorand.node.Configure
   name: test
   data_dir: /etc/algorand/node_dirs/node/test/latest/data
   kmd_dir: /etc/algorand/node_dirs/node/test/latest/kmd
-  algod_port: 60004
-  kmd_port: 60005
-  archival_node: true
+  node_configs:
+    EndpointAddress: 0.0.0.0:60004
+    Archival: true
+  kmd_configs:
+    address: 0.0.0.0:60005
 
 
 - task: algorand.node.Start

--- a/test/test-yamls/valid/algorand-test.yaml
+++ b/test/test-yamls/valid/algorand-test.yaml
@@ -66,6 +66,22 @@ tasks:
   kmd_dir: /etc/algorand/node_dirs/node/test/latest/kmd
   bin_dir: /etc/algorand/node_dirs/node/test/latest/bin
 
+- task: algorand.node.Restart
+  name: stable
+  data_dir: /etc/algorand/node_dirs/node/stable/latest/data
+  kmd_dir: /etc/algorand/node_dirs/node/stable/latest/kmd
+  bin_dir: /etc/algorand/node_dirs/node/stable/latest/bin
+- task: algorand.node.Restart
+  name: beta
+  data_dir: /etc/algorand/node_dirs/node/beta/latest/data
+  kmd_dir: /etc/algorand/node_dirs/node/beta/latest/kmd
+  bin_dir: /etc/algorand/node_dirs/node/beta/latest/bin
+- task: algorand.node.Restart
+  name: test
+  data_dir: /etc/algorand/node_dirs/node/test/latest/data
+  kmd_dir: /etc/algorand/node_dirs/node/test/latest/kmd
+  bin_dir: /etc/algorand/node_dirs/node/test/latest/bin
+
 
 - task: algorand.node.Stop
   name: stable
@@ -125,3 +141,8 @@ jobs:
     - algorand.node.Stop.stable
     - algorand.node.Stop.beta
     - algorand.node.Stop.test
+  restart-nodes:
+    tasks:
+    - algorand.node.Restart.stable
+    - algorand.node.Restart.beta
+    - algorand.node.Restart.test

--- a/test/test-yamls/valid/algorand-test.yaml
+++ b/test/test-yamls/valid/algorand-test.yaml
@@ -83,15 +83,28 @@ tasks:
   kmd_dir: /etc/algorand/node_dirs/node/test/latest/kmd
   bin_dir: /etc/algorand/node_dirs/node/test/latest/bin
 
+
 - task: shell.Shell
   name: status-beta
   command: /etc/algorand/node_dirs/node/beta/latest/bin/goal -d /etc/algorand/node_dirs/node/beta/latest/data node status
+- task: shell.Shell
+  name: status-stable
+  command: /etc/algorand/node_dirs/node/stable/latest/bin/goal -d /etc/algorand/node_dirs/node/stable/latest/data node status
+- task: shell.Shell
+  name: status-test
+  command: /etc/algorand/node_dirs/node/test/latest/bin/goal -d /etc/algorand/node_dirs/node/test/latest/data node status
 
 
 jobs:
-  status-beta:
+  status-betanet:
     tasks:
     - shell.Shell.status-beta
+  status-mainnet:
+    tasks:
+    - shell.Shell.status-stable
+  status-testnet:
+    tasks:
+    - shell.Shell.status-test
   install-nodes:
     tasks:
     - algorand.node.Install.stable

--- a/test/test-yamls/valid/algorand-test.yaml
+++ b/test/test-yamls/valid/algorand-test.yaml
@@ -1,0 +1,107 @@
+tasks:
+- task: algorand.node.Install
+  name: stable
+  data_dir: /etc/algorand/node_dirs/node/stable/latest/data
+  bin_dir: /etc/algorand/node_dirs/node/stable/latest/bin
+  channel: stable
+  version: latest
+- task: algorand.node.Install
+  name: beta
+  data_dir: /etc/algorand/node_dirs/node/beta/latest/data
+  bin_dir: /etc/algorand/node_dirs/node/beta/latest/bin
+  channel: beta
+  version: latest
+- task: algorand.node.Install
+  name: test
+  data_dir: /etc/algorand/node_dirs/node/test/latest/data
+  bin_dir: /etc/algorand/node_dirs/node/test/latest/bin
+  channel: stable
+  version: latest
+- task: shell.shell
+  command: /etc/algorand/node_dirs/node/test/latest/data/genesis
+
+- task: algorand.node.Configure
+  name: stable
+  data_dir: /etc/algorand/node_dirs/node/stable/latest/data
+  kmd_dir: /etc/algorand/node_dirs/node/stable/latest/kmd
+  algod_port: 60000
+  kmd_port: 60001
+  archival_node: true
+- task: algorand.node.Configure
+  name: beta
+  data_dir: /etc/algorand/node_dirs/node/beta/latest/data
+  kmd_dir: /etc/algorand/node_dirs/node/beta/latest/kmd
+  algod_port: 60002
+  kmd_port: 60003
+  archival_node: true
+- task: algorand.node.Configure
+  name: test
+  data_dir: /etc/algorand/node_dirs/node/test/latest/data
+  kmd_dir: /etc/algorand/node_dirs/node/test/latest/kmd
+  algod_port: 60004
+  kmd_port: 60005
+  archival_node: true
+
+
+- task: algorand.node.Start
+  name: stable
+  data_dir: /etc/algorand/node_dirs/node/stable/latest/data
+  kmd_dir: /etc/algorand/node_dirs/node/stable/latest/kmd
+  bin_dir: /etc/algorand/node_dirs/node/stable/latest/bin
+- task: algorand.node.Start
+  name: beta
+  data_dir: /etc/algorand/node_dirs/node/beta/latest/data
+  kmd_dir: /etc/algorand/node_dirs/node/beta/latest/kmd
+  bin_dir: /etc/algorand/node_dirs/node/beta/latest/bin
+- task: algorand.node.Start
+  name: test
+  data_dir: /etc/algorand/node_dirs/node/test/latest/data
+  kmd_dir: /etc/algorand/node_dirs/node/test/latest/kmd
+  bin_dir: /etc/algorand/node_dirs/node/test/latest/bin
+
+
+- task: algorand.node.Stop
+  name: stable
+  data_dir: /etc/algorand/node_dirs/node/stable/latest/data
+  kmd_dir: /etc/algorand/node_dirs/node/stable/latest/kmd
+  bin_dir: /etc/algorand/node_dirs/node/stable/latest/bin
+- task: algorand.node.Stop
+  name: beta
+  data_dir: /etc/algorand/node_dirs/node/beta/latest/data
+  kmd_dir: /etc/algorand/node_dirs/node/beta/latest/kmd
+  bin_dir: /etc/algorand/node_dirs/node/beta/latest/bin
+- task: algorand.node.Stop
+  name: test
+  data_dir: /etc/algorand/node_dirs/node/test/latest/data
+  kmd_dir: /etc/algorand/node_dirs/node/test/latest/kmd
+  bin_dir: /etc/algorand/node_dirs/node/test/latest/bin
+
+- task: shell.Shell
+  name: status-beta
+  command: /etc/algorand/node_dirs/node/beta/latest/bin/goal -d /etc/algorand/node_dirs/node/beta/latest/data node status
+
+
+jobs:
+  status-beta:
+    tasks:
+    - shell.Shell.status-beta
+  install-nodes:
+    tasks:
+    - algorand.node.Install.stable
+    - algorand.node.Install.beta
+    - algorand.node.Install.test
+  configure-nodes:
+    tasks:
+    - algorand.node.Configure.stable
+    - algorand.node.Configure.beta
+    - algorand.node.Configure.test
+  start-nodes:
+    tasks:
+    - algorand.node.Start.stable
+    - algorand.node.Start.beta
+    - algorand.node.Start.test
+  stop-nodes:
+    tasks:
+    - algorand.node.Stop.stable
+    - algorand.node.Stop.beta
+    - algorand.node.Stop.test

--- a/test/test-yamls/valid/algorand-test.yaml
+++ b/test/test-yamls/valid/algorand-test.yaml
@@ -112,16 +112,21 @@ tasks:
   bin_dir: /etc/algorand/node_dirs/node/test/latest/bin
 
 
-- task: shell.Shell
-  name: status-beta
-  command: /etc/algorand/node_dirs/node/beta/latest/bin/goal -d /etc/algorand/node_dirs/node/beta/latest/data node status
-- task: shell.Shell
-  name: status-stable
-  command: /etc/algorand/node_dirs/node/stable/latest/bin/goal -d /etc/algorand/node_dirs/node/stable/latest/data node status
-- task: shell.Shell
-  name: status-test
-  command: /etc/algorand/node_dirs/node/test/latest/bin/goal -d /etc/algorand/node_dirs/node/test/latest/data node status
-
+- task: algorand.node.Status
+  name: stable
+  data_dir: /etc/algorand/node_dirs/node/stable/latest/data
+  kmd_dir: /etc/algorand/node_dirs/node/stable/latest/kmd
+  bin_dir: /etc/algorand/node_dirs/node/stable/latest/bin
+- task: algorand.node.Status
+  name: beta
+  data_dir: /etc/algorand/node_dirs/node/beta/latest/data
+  kmd_dir: /etc/algorand/node_dirs/node/beta/latest/kmd
+  bin_dir: /etc/algorand/node_dirs/node/beta/latest/bin
+- task: algorand.node.Status
+  name: test
+  data_dir: /etc/algorand/node_dirs/node/test/latest/data
+  kmd_dir: /etc/algorand/node_dirs/node/test/latest/kmd
+  bin_dir: /etc/algorand/node_dirs/node/test/latest/bin
 
 jobs:
   show-configs:
@@ -131,13 +136,13 @@ jobs:
     - algorand.node.ShowConfigs.test
   status-betanet:
     tasks:
-    - shell.Shell.status-beta
+    - algorand.node.Status.beta
   status-mainnet:
     tasks:
-    - shell.Shell.status-stable
+    - algorand.node.Status.stable
   status-testnet:
     tasks:
-    - shell.Shell.status-test
+    - algorand.node.Status.test
   install-nodes:
     tasks:
     - algorand.node.Install.stable

--- a/test/test-yamls/valid/algorand-test.yaml
+++ b/test/test-yamls/valid/algorand-test.yaml
@@ -49,6 +49,18 @@ tasks:
   kmd_configs:
     address: 0.0.0.0:60005
 
+- task: algorand.node.ShowConfigs
+  name: stable
+  data_dir: /etc/algorand/node_dirs/node/stable/latest/data
+  kmd_dir: /etc/algorand/node_dirs/node/stable/latest/kmd
+- task: algorand.node.ShowConfigs
+  name: beta
+  data_dir: /etc/algorand/node_dirs/node/beta/latest/data
+  kmd_dir: /etc/algorand/node_dirs/node/beta/latest/kmd
+- task: algorand.node.ShowConfigs
+  name: test
+  data_dir: /etc/algorand/node_dirs/node/test/latest/data
+  kmd_dir: /etc/algorand/node_dirs/node/test/latest/kmd
 
 - task: algorand.node.Start
   name: stable
@@ -112,6 +124,11 @@ tasks:
 
 
 jobs:
+  show-configs:
+    tasks:
+    - algorand.node.ShowConfigs.stable
+    - algorand.node.ShowConfigs.beta
+    - algorand.node.ShowConfigs.test
   status-betanet:
     tasks:
     - shell.Shell.status-beta


### PR DESCRIPTION
This adds some mule tasks we can use to set up algorand nodes for any purpose we need. They can install any version of algorand we need, accept node/kmd configs and start/stop nodes. I included an example mule.yaml at `test/test-yamls/valid/algorand-test.yaml`, which is what we're using for our catchpoint node installation. I also updated our s3_utils to allow unauthenticated requests to s3 for get operations so that our node tasks can query s3 without authenticating on public buckets.

Test instructions:
```
docker run -ti -w /mule -v `pwd`:/mule python:3.7 bash
pip install -e .
mule -f test/test-yamls/valid/algorand-test.yaml install-nodes
mule -f test/test-yamls/valid/algorand-test.yaml configure-nodes
mule -f test/test-yamls/valid/algorand-test.yaml start-nodes

mule -f test/test-yamls/valid/algorand-test.yaml status-betanet
mule -f test/test-yamls/valid/algorand-test.yaml status-testnet
mule -f test/test-yamls/valid/algorand-test.yaml status-mainnet
```