### PR TITLE
Add support for parameterized go version

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# go_algorand_ci code owners file
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+*       @btoll
+*       @bricerisignalgorand
+*       @onetechnical
+*       @egieseke

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,0 @@
-# go_algorand_ci code owners file
-# Lines starting with '#' are comments.
-# Each line is a file pattern followed by one or more owners.
-
-# These owners will be the default owners for everything in the repo.
-*       @btoll
-*       @bricerisignalgorand
-*       @onetechnical
-*       @egieseke

--- a/mule/task/shell/__init__.py
+++ b/mule/task/shell/__init__.py
@@ -10,9 +10,10 @@ class IShellTask(ITask):
         if self.save_logs:
             print(f"running sub process {self.command}")
             command_logs = subprocess.run(self.command, capture_output=True, check=True)
-            print(f"command logs { command_logs.stdout.decode('utf-8')  }")
             return {
-                'logs': command_logs.stdout.decode('utf-8').rstrip("\n")
+                'stdout': command_logs.stdout.decode('utf-8').rstrip("\n"),
+                'stderr': command_logs.stderr.decode('utf-8').rstrip("\n"),
+                'returncode': command_logs.returncode
             }
         else:
             subprocess.run(self.command, check=True)

--- a/mule/task/shell/__init__.py
+++ b/mule/task/shell/__init__.py
@@ -3,9 +3,19 @@ import subprocess
 
 class IShellTask(ITask):
 
+    save_logs = False
+
     def execute(self, job_context):
         super().execute(job_context)
-        subprocess.run(self.command, check=True)
+        if self.save_logs:
+            print(f"running sub process {self.command}")
+            command_logs = subprocess.run(self.command, capture_output=True, check=True)
+            print(f"command logs { command_logs.stdout.decode('utf-8')  }")
+            return {
+                'logs': command_logs.stdout.decode('utf-8').rstrip("\n")
+            }
+        else:
+            subprocess.run(self.command, check=True)
 
 class Shell(IShellTask):
 
@@ -18,9 +28,11 @@ class Shell(IShellTask):
         self.command = args['command']
         if type(self.command) == str:
             self.command = self.command.split(' ')
+        if 'saveLogs' in args:
+            self.save_logs = args['saveLogs']
 
     def execute(self, job_context):
-        super().execute(job_context)
+        return super().execute(job_context)
 
 class Make(IShellTask):
 

--- a/mule/task/shell/docker.py
+++ b/mule/task/shell/docker.py
@@ -30,10 +30,10 @@ class Ensure(ITask):
         'version',
         'image',
         'dockerFilePath',
-        'arch',
-        'goVersion'
+        'arch'
     ]
-    buildContextPath= "."
+    buildContextPath = "."
+    goVersion = ""
 
     def __init__(self, args):
         super().__init__(args)
@@ -41,9 +41,10 @@ class Ensure(ITask):
         self.image = args['image']
         self.version = args['version']
         self.dockerFilePath = args['dockerFilePath']
-        self.goVersion = args['goVersion']
         if 'buildContextPath' in args:
             self.buildContextPath = args['buildContextPath']
+        if 'goVersion' in args:
+            self.goVersion = args['goVersion']
 
     def execute(self, job_context):
         super().execute(job_context)

--- a/mule/task/shell/docker.py
+++ b/mule/task/shell/docker.py
@@ -31,6 +31,7 @@ class Ensure(ITask):
         'image',
         'dockerFilePath',
         'arch',
+        'goVersion'
     ]
     buildContextPath= "."
 
@@ -40,10 +41,11 @@ class Ensure(ITask):
         self.image = args['image']
         self.version = args['version']
         self.dockerFilePath = args['dockerFilePath']
+        self.goVersion = args['goVersion']
         if 'buildContextPath' in args:
             self.buildContextPath = args['buildContextPath']
 
     def execute(self, job_context):
         super().execute(job_context)
         print('Checking to see if docker image is available')
-        docker.ensure(f"{self.image}:{self.version}", self.arch, self.buildContextPath, self.dockerFilePath)
+        docker.ensure(f"{self.image}:{self.version}", self.arch, self.goVersion, self.buildContextPath, self.dockerFilePath)

--- a/mule/util/docker_util.py
+++ b/mule/util/docker_util.py
@@ -59,7 +59,7 @@ def checkForLocalImage(docker_image_name) :
     return found
 
 # Ensure that the docker image exist for the current configuration file
-def ensure(image, arch, build_context_path, docker_file_path):
+def ensure(image, arch, go_version, build_context_path, docker_file_path):
     if checkForLocalImage(image):
         cprint(
             f"Found docker image {image} locally",
@@ -72,7 +72,7 @@ def ensure(image, arch, build_context_path, docker_file_path):
                 'green',
             )
         else:
-            build([f"ARCH={arch}"], build_context_path, [image], docker_file_path)
+            build([f"ARCH={arch}", f"GOLANG_VERSION={go_version}"], build_context_path, [image], docker_file_path)
             cprint(
                 f"Built docker image {image} from {docker_file_path}",
                 'green',


### PR DESCRIPTION
Updated mule to support a parametrized go version retrieved from the go.mod file.  The go version is now included in the docker image tag.   