### PR TITLE
Update algorand install to support nightly channel

### DIFF
--- a/mule/util/algorand_util.py
+++ b/mule/util/algorand_util.py
@@ -60,6 +60,11 @@ def install_node(data_dir, bin_dir, channel, node_package_version='latest'):
             os.path.join(node_package_dir, "genesis/mainnet/genesis.json"),
             os.path.join(data_dir, 'genesis.json')
         )
+    elif channel == 'nightly':
+        file_util.copy_file(
+            os.path.join(node_package_dir, "genesis/devnet/genesis.json"),
+            os.path.join(data_dir, 'genesis.json')
+        )
     else:
         file_util.copy_file(
             os.path.join(node_package_dir, f"genesis/{channel}net/genesis.json"),


### PR DESCRIPTION
The installer needs to select the correct genesis file when installing the nightly channel