### PR TITLE
Fix bug in list-agents when verbose

### DIFF
--- a/mule/driver.py
+++ b/mule/driver.py
@@ -47,7 +47,7 @@ def _read_mule_yamls(mule_yamls):
 def _list_agents(agent_configs, verbose):
     for agent in agent_configs:
         if verbose:
-            print(agent['name'], prettify_json(agent_configs))
+            print(agent['name'], prettify_json(agent))
         else:
             print(agent['name'])
 


### PR DESCRIPTION
`--list-agents --verbose` was wrongly listing every agent for each agent.