### PR TITLE
Added list-env functionality for printing out a job's customizable env vars

### DIFF
--- a/mule/driver.py
+++ b/mule/driver.py
@@ -1,4 +1,5 @@
 from termcolor import cprint
+import os
 import sys
 
 import mule.parser
@@ -13,16 +14,18 @@ def main():
     args = mule.parser.parseArgs()
     try:
         mule_yamls = args.file
-        if len(args.file) == 0:
+        if len(mule_yamls) == 0:
             mule_yamls.append('mule.yaml')
         mule_config = _read_mule_yamls(mule_yamls)
 
         if args.list_agents:
-            parsed_mule_config = yaml_util.readYaml(mule_config)
-            _list_agents(parsed_mule_config["agents"], args.verbose)
+            _, _, agent_configs = _get_list_configs(mule_config)
+            _list_agents(agent_configs, args.verbose)
+        elif args.list_env:
+            job_name = args.list_env
+            _list_env(mule_config, job_name, args.verbose)
         else:
-            parsed_mule_config = yaml_util.readYaml(mule_config, raw=False)
-            jobs_config, task_configs, agent_configs = validator.getValidatedMuleYaml(parsed_mule_config)
+            jobs_config, task_configs, agent_configs = _get_list_configs(mule_config, False)
             if args.list_jobs:
                 _list_jobs(jobs_config, args.verbose)
             elif args.list_tasks:
@@ -37,6 +40,10 @@ def main():
             file = sys.stderr
         )
         raise error
+
+def _get_list_configs(mule_config, raw=True):
+    parsed_mule_config = yaml_util.readYaml(mule_config, raw)
+    return validator.getValidatedMuleYaml(parsed_mule_config)
 
 def _read_mule_yamls(mule_yamls):
     mule_config = {}
@@ -54,6 +61,48 @@ def _list_agents(agent_configs, verbose):
             print(agent['name'], pjson(agent_configs))
         else:
             print(agent['name'])
+
+def _list_env(mule_config, job_name, verbose):
+    jobs_config, task_configs, agent_configs = _get_list_configs(mule_config)
+
+    if not job_name in jobs_config:
+        raise Exception(messages.JOB_NOT_FOUND.format(job_name))
+    else:
+        tasks = jobs_config[job_name]["tasks"]
+        # Different tasks can have the same agent, so let's use a set.
+        agents = set()
+
+        for task in tasks:
+            # Now that we have each task, loop over the yaml task configs (tasks)
+            # to determine the agent defined for the specified tasks.
+            for t_c in task_configs:
+                # Recall that tasks may not have a "name" key.
+                if t_c["task"] in task and "name" in t_c and t_c["name"] in task:
+                    agents.add(t_c["agent"])
+
+        # If we're not concerned with knowing each agent config and whether or not
+        # it has defined env vars (or anything else), we could improve this from
+        # O(n^2) time to O(n) by simply checking if an agent_config["name"] is in
+        # the set and then hoovering up the env vars (however, we wouldn't then know
+        # anything about individual agents).
+        #
+        # However, it's useful to know the names of which agent configs DON'T
+        # contain any env vars, for example, so then we can print that to STDOUT.
+        for agent in agents:
+            for a_c in agent_configs:
+                if agent == a_c["name"]:
+                    if "env" in a_c and a_c["name"] in agents:
+                        # Only evaluate the env vars if `verbose` flag is set.
+                        if verbose:
+                            captured = []
+                            for env in a_c["env"]:
+                                [name, value] = env.split("=")
+                                captured.append("=".join((name, os.path.expandvars(value))))
+                            print(f"agent `{agent}`: {captured}")
+                        else:
+                            print(f"agent `{agent}`: {a_c['env']}")
+                    else:
+                        print(f"agent `{agent}`: None")
 
 def _list_jobs(jobs_config, verbose):
     for job in jobs_config.keys():

--- a/mule/driver.py
+++ b/mule/driver.py
@@ -16,7 +16,7 @@ def main():
         if len(mule_yamls) == 0:
             mule_yamls.append('mule.yaml')
         mule_config = _read_mule_yamls(mule_yamls)
-        agent_configs, jobs_config, task_configs = _get_list_configs(mule_config, raw=yaml_read_raw(args))
+        agent_configs, jobs_config, task_configs = _get_configs(mule_config, raw=yaml_read_raw(args))
 
         if args.list_agents:
             _list_agents(agent_configs, args.verbose)
@@ -37,7 +37,7 @@ def main():
         )
         raise error
 
-def _get_list_configs(mule_config, raw):
+def _get_configs(mule_config, raw):
     parsed_mule_config = yaml_util.read_yaml(mule_config, raw)
     return validator.get_validated_mule_yaml(parsed_mule_config)
 

--- a/mule/driver.py
+++ b/mule/driver.py
@@ -1,6 +1,7 @@
 from termcolor import cprint
 import os
 import sys
+import yaml
 
 import mule.parser
 import mule.validator as validator
@@ -86,6 +87,7 @@ def _list_env(agent_configs, jobs_config, task_configs, job_name, verbose):
         #
         # However, it's useful to know the names of which agent configs DON'T
         # contain any env vars, for example, so then we can print that to STDOUT.
+        items = {}
         for agent in agents:
             for a_c in agent_configs:
                 if agent == a_c["name"]:
@@ -97,9 +99,12 @@ def _list_env(agent_configs, jobs_config, task_configs, job_name, verbose):
                             for env in a_c["env"]:
                                 [name, value] = env.split("=")
                                 envs.append("=".join((name, os.path.expandvars(value))))
-                        print(f"agent `{agent}`: {prettify_json(envs)}")
+                        items[agent] = envs
                     else:
-                        print(f"agent `{agent}`: None")
+                        items[agent] = None
+
+        print(yaml.dump(items))
+        return items
 
 def _list_jobs(jobs_config, verbose):
     for job in jobs_config.keys():

--- a/mule/driver.py
+++ b/mule/driver.py
@@ -71,7 +71,11 @@ def _list_env(agent_configs, jobs_config, task_configs, job_name, verbose):
             # to determine the agent defined for the specified tasks.
             for t_c in task_configs:
                 # Recall that tasks may not have a "name" key.
-                if t_c["task"] in task and "name" in t_c and t_c["name"] in task:
+                if (
+                    # For example, "".join((t_c["task"], ".", t_c["name"])) matches `docker.Make.deb`.
+                    "name" in t_c and "".join((t_c["task"], ".", t_c["name"])) == task or
+                    t_c["task"] == task
+                ):
                     agents.add(t_c["agent"])
 
         # If we're not concerned with knowing each agent config and whether or not

--- a/mule/parser.py
+++ b/mule/parser.py
@@ -51,6 +51,13 @@ def parseArgs():
     )
 
     group.add_argument(
+        '--list-env',
+        action = 'store',
+        dest = 'list_env',
+        help = 'lists the env vars needed for the given job',
+    )
+
+    group.add_argument(
         'JOB',
         help="name of job you would like to execute",
         nargs='?',


### PR DESCRIPTION
```
$ mule -f package-sign.yaml --list-env package-sign
deb:
- AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
- AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
- BRANCH=$BRANCH
- CHANNEL=$CHANNEL
- S3_SOURCE=$S3_SOURCE
- VERSION=$VERSION
```

Adding the `--verbose` flag will evaluate the env vars:
```
$ mule -f package-sign.yaml --list-env package-sign --verbose
deb:
- AWS_ACCESS_KEY_ID=foo
- AWS_SECRET_ACCESS_KEY=bar
- BRANCH=rel/stable
- CHANNEL=stable
- S3_SOURCE=$S3_SOURCE
- VERSION=2.2.0
```
In verbose mode, note that any env vars not defined in the calling environment will simply print the expected var name, as in the `S3_SOURCE` entry in the above example.