### PR TITLE
Added command substitution to agent `env` values

### DIFF
--- a/mule/error/messages.py
+++ b/mule/error/messages.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+BAD_VOLUME_CONFIG="One or more docker volumes are misconfigured: '{}'"
 BUCKET_UPLOAD_SRC_DEST="Source '{}' and destination '{}' configs cannot both be local"
 CANNOT_EVALUATE_ENV_VAR="Could not evaluate environment variable {} referenced in mule yaml file"
 CANNOT_LOCATE_TASK="Could not locate task with name {}\nPlease reference documentation or submit an issue"

--- a/mule/error/messages.py
+++ b/mule/error/messages.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-BAD_VOLUME_CONFIG="One or more docker volumes are misconfigured: '{}'"
+AGENT_FIELD_WRONG_FORMAT="Agent `{}` has an item '{}' with the wrong format"
+AGENT_FIELD_WRONG_TYPE="Agent `{}` has an item '{}' with the wrong type, expected {} got {}"
 BUCKET_UPLOAD_SRC_DEST="Source '{}' and destination '{}' configs cannot both be local"
 CANNOT_EVALUATE_ENV_VAR="Could not evaluate environment variable {} referenced in mule yaml file"
 CANNOT_LOCATE_TASK="Could not locate task with name {}\nPlease reference documentation or submit an issue"


### PR DESCRIPTION
## Summary

Added command substitution to agent `env` values.  This brings feature parity with the `buildArgs` config.

- fixed bug in subprocess.run (create an array first)
- changed function name format to be pythonic

This continues to get us closer to full automation as allowing for command substitution in "env" will potentially allow for the removal of some environment variables that are computed at runtime in the task shell scripts.

## Test Plan

Apply this patch:
```
diff --git a/Makefile b/Makefile
index 0966d019..8132f97d 100644
--- a/Makefile
+++ b/Makefile
@@ -308,3 +308,6 @@ archive:
        CHANNEL=$(CHANNEL) \
        aws s3 cp tmp/node_pkgs s3://algorand-internal/channel/${CHANNEL}/$(FULLBUILDNUMBER) --recursive --exclude "*" --include "*${CHANNEL}*$(FULLBUILDNUMBER)*"
 
+hello:
+       echo hello world!
+
diff --git a/package.yaml b/package.yaml
index d5d8de0d..e5adf0ec 100644
--- a/package.yaml
+++ b/package.yaml
@@ -17,8 +17,10 @@ agents:
     buildArgs:
       - GOLANG_VERSION=`./scripts/get_golang_version.sh`
     env:
-      - NETWORK=$NETWORK
-      - VERSION=$VERSION
+      - NETWORK=mainnet
+      - VERSION=`echo 2.1.1`
+      - ARCH_TYPE=`uname -m`
+      - OS_TYPE=`./scripts/ostype.sh`
     workDir: $HOME/projects/go-algorand
 
   - name: docker
@@ -55,7 +57,16 @@ tasks:
     agent: docker
     target: mule-package-docker
 
+  - task: docker.Make
+    name: hello
+    agent: rpm
+    target: hello
+
 jobs:
+  hello:
+    tasks:
+      - docker.Make.hello
+
   package:
     tasks:
       - docker.Make.build
```
Then, run `mule -f package.yaml hello`.
