### PR TITLE
Use console_scripts entry point to simplify cli setup

### DIFF
--- a/bin/mule
+++ b/bin/mule
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-import sys
-import mule.driver
-
-def main():
-    return mule.driver.main()
-
-if __name__ == '__main__':
-    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ from mule import __version__
 setuptools.setup(
     name='mulecli',
     version=__version__,
-    scripts=['bin/mule'],
     description='Script for executing automated tasks',
     packages=setuptools.find_packages(),
     python_requires='>=3.5',
@@ -30,4 +29,9 @@ setuptools.setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',
     ],
+    entry_points={
+        "console_scripts": [
+            "mule = mule.driver:main"
+        ]
+    }
 )


### PR DESCRIPTION
## Summary

Using the `console_scripts` entry point allows us to remove the cli shell script in `bin/`.  It will create a generated shell script and put it in a directory in `$PATH` (on my machine it put it in `/usr/local/bin`).

The cli `mule` is still called as usual.  There is nothing that would impact the user and in no way breaks any expected behavior.  It is completely transparent.

The advantage of leveraging python's native tooling is not only that it allows us to remove the `bin/mule` shell script but it allows other tooling to take advantage of these kinds of entry points.

Most importantly, having the tooling create the"binary" allows this to be cross-platform.  The tooling figures out how to put the script in the PATH for all platforms.

## Test Plan

```
python setup.py install
```
