### PR TITLE
--list-env: Check for agent in task config

### DIFF
--- a/mule/parser.py
+++ b/mule/parser.py
@@ -51,6 +51,7 @@ def parseArgs():
     )
 
     group.add_argument(
+        '-l',
         '--list-env',
         action = 'store',
         dest = 'list_env',


### PR DESCRIPTION
## Summary

The implementation of the `--list-env` command wasn't properly checking for any defined agents in a task, and this led to an unseemly error.

We now check for that and print a helpful message.

## Test Plan

Run any `mule` job that references a task without a defined agent.
