### PR TITLE
Added pre-commit hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,33 @@ To install mule using pip, use:
 pip install mulecli
 ```
 
+## Git Hooks
+
+There are two custom `pre-commit` hooks that can be easily installed by running the `install.sh` script found within the `./scripts/hooks/` directory:
+
+```
+./scripts/hooks/install.sh
+```
+
+These will install two local `pre-commit` hooks in `./.git/config`. The hooks have two dependencies, [pytest] and [pycodestyle]. There are no default filters for [pycodestyle], that is left up to the developer.
+
+`pytest` is already a dependency of `mule`. To install `pycodestyle`:
+
+```
+python -m pip pycodestyle
+```
+
+Once installed, they can be ignored when committing, if needed:
+
+```
+git commit --no-verify
+```
+
 # Navigation
 * [Getting Started Guide](docs/getting_started.md)
 * [Task Documentation](docs/tasks/README.md)
 * [How to Contribute](docs/contribution.md)
+
+[pytest](https://pypi.org/project/pytest/)
+[pycodestyle](https://pypi.org/project/pycodestyle/)
+

--- a/scripts/hooks/install.sh
+++ b/scripts/hooks/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "$(tput setaf 2)[INFO]$(tput sgr0) Adding pre-commit hooks to .gitconfig..."
-git config --global --add hooks.pre-commit.mule "pycodestyle.sh"
-git config --global --add hooks.pre-commit.mule "pytest.sh"
+echo "$(tput setaf 2)[INFO]$(tput sgr0) Adding local pre-commit hooks to .git/config..."
+git config --local --add hooks.pre-commit.mule "pycodestyle.sh"
+git config --local --add hooks.pre-commit.mule "pytest.sh"
 

--- a/scripts/hooks/install.sh
+++ b/scripts/hooks/install.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "$(tput setaf 2)[INFO]$(tput sgr0) Adding pre-commit hooks to .gitconfig..."
+git config --global --add hooks.pre-commit.mule "pycodestyle.sh"
+git config --global --add hooks.pre-commit.mule "pytest.sh"
+

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Try for local hooks first.
+STR=$(git config --get-all --local hooks.pre-commit.mule)
+
+if [ -z "$STR" ]; then
+    STR=$(git config --get-all hooks.pre-commit.mule)
+fi
+
+if [ -n "$STR" ]; then
+    for HOOK in $STR; do
+        bash "./.git/hooks/pre-commit.d/$HOOK"
+
+        if [ "$?" -eq 1 ]; then
+            exit 1
+        else
+            # Separate the hooks by an empty line.
+            echo
+        fi
+    done
+fi
+

--- a/scripts/hooks/pre-commit.d/pycodestyle.sh
+++ b/scripts/hooks/pre-commit.d/pycodestyle.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+if ! which pycodestyle > /dev/null
+then
+    echo "$(tput setab 7)$(tput setaf 4)[INFO]$(tput sgr0) $(tput bold)pycodestyle$(tput sgr0) is not present on the system..."
+    exit 0
+fi
+
+FILES=$(git diff-index --cached --name-only HEAD 2> /dev/null | grep ".py\b")
+
+if [ -n "$FILES" ]
+then
+    echo "$(tput setab 7)$(tput setaf 4)[INFO]$(tput sgr0) Running $(tput bold)pycodestyle$(tput sgr0) pre-commit hook..."
+
+    for file in $FILES
+    do
+        pycodestyle "$file"
+
+        if [ "$?" -eq 1 ]
+        then
+            # Note that pycodestyle's error messages are verbose enough that we don't need to have our own.
+            EXIT_CODE=1
+        fi
+    done
+
+    if [ $EXIT_CODE -eq 0 ]
+    then
+        echo "$(tput setab 7)$(tput setaf 2)[INFO]$(tput sgr0) Completed successfully."
+    fi
+fi
+
+exit $EXIT_CODE
+

--- a/scripts/hooks/pre-commit.d/pytest.sh
+++ b/scripts/hooks/pre-commit.d/pytest.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+if ! which pytest > /dev/null
+then
+    echo "$(tput setab 7)$(tput setaf 4)[INFO]$(tput sgr0) $(tput bold)pytest$(tput sgr0) is not present on the system..."
+    exit 0
+fi
+
+FILES=$(git diff-index --cached --name-only HEAD 2> /dev/null | grep ".py\b")
+
+if [ -n "$FILES" ]
+then
+    echo "$(tput setab 7)$(tput setaf 4)[INFO]$(tput sgr0) Running $(tput bold)pytest$(tput sgr0) pre-commit hook..."
+
+    cd tests || exit
+    pytest -v
+    EXIT_CODE="$?"
+
+    if [ $EXIT_CODE -eq 0 ]
+    then
+        echo "$(tput setab 7)$(tput setaf 2)[INFO]$(tput sgr0) Completed successfully."
+    fi
+fi
+
+exit $EXIT_CODE
+


### PR DESCRIPTION
## Summary

Added two git pre-commit hooks.  One is for `pytest` for the unit tests and the other is for `pycodestyle`, a PEP8 linter.  Installing is not mandatory, but it's a nice-to-have.

If installed, the git hooks can be bypassed when committing (for instance, in the case that there are too many linter warnings):
```
git commit --no-verify
```

I know they work because I'm using them.