### PR TITLE
Remove empty values from `env` block

### DIFF
--- a/tests/task/docker.yaml
+++ b/tests/task/docker.yaml
@@ -1,0 +1,19 @@
+#!mule
+agents:
+  - name: deb
+    dockerFilePath: docker/build/cicd.ubuntu.Dockerfile
+    image: algorand/go-algorand-ci-linux-ubuntu
+    version: scripts/configure_dev-deps.sh
+    workDir: $HOME/projects/go-algorand
+
+tasks:
+  - task: docker.Make
+    name: deb
+    agent: deb
+    target: hello
+
+jobs:
+  deb:
+    tasks:
+      - docker.Make.deb
+

--- a/tests/task/test_docker.py
+++ b/tests/task/test_docker.py
@@ -1,0 +1,28 @@
+import pytest
+
+from mule import mule
+from mule.task.docker import Make
+
+
+@pytest.fixture(scope="module")
+def mule_make_instance():
+    mule_configs = mule.get_configs("docker.yaml", raw=True)
+    deb = mule_configs.get("tasks")[0]
+    return Make(deb)
+
+
+# This tests both lists and dicts.
+@pytest.mark.parametrize("mule_make_instance, block, delimiter", [
+    (mule_make_instance, ["FOO=foo", "BAR=bar"], "="),
+    (mule_make_instance, ["FOO=foo", "", "BAR=bar"], "="),
+    (mule_make_instance, ["", "FOO=foo", "", "BAR=bar", ""], "="),
+    (mule_make_instance, ["", "", "FOO=foo", "", "BAR=bar", ""], "="),
+    (mule_make_instance, ["", "", "", "", "", "FOO=foo", "BAR=bar"], "="),
+    (mule_make_instance, {"FOO": "foo", "BAR": "bar"}, ":"),
+    (mule_make_instance, {"FOO": "foo", "QUUX": "", "BAR": "bar"}, ":"),
+    (mule_make_instance, {"QUUX": "", "FOO": "foo", "ZIP": "", "BAR": "bar", "DERP": ""}, ":"),
+    (mule_make_instance, {"KILGORE": "", "TROUT": "", "FOO": "foo", "ZIP": "", "BAR": "bar", "": ""}, ":"),
+], indirect=["mule_make_instance"])
+def test_format_block_list(mule_make_instance, block, delimiter):
+    formatted_list = mule_make_instance.format_block(block, delimiter)
+    assert formatted_list == [f"FOO{delimiter}foo", f"BAR{delimiter}bar"]


### PR DESCRIPTION
## Summary

This is a blocker.

When recipes or cli env vars contain empty values, i.e. "FOO=", "", the docker task will throw an exception.  This is because the following isn't valid syntax in a `docker run` command:
`docker run -e ""` etc.

## Test Plan

Tested manually and via unit tests.
