### PR TITLE
Implement docker archetype

### DIFF
--- a/mule/ci/README.md
+++ b/mule/ci/README.md
@@ -1,0 +1,12 @@
+# muleci
+
+This package is for code related to the muleci project.
+
+## Archetypes
+Archetypes are generic pipeline implementations for different stacks. They all implement [IArchetype](archetype/__init__.py) so that muleci knows how to perform pipeline operations. When implementing an archetype, you have the option to implement each action supported by the muleci cli (build, publish, deploy, etc)
+
+* [docker](archetype/docker.py)
+    * Used to generically build/publish/deploy any project with a Dockerfile in the root directory. It uses git commit hashes for versioning.
+* [npm](archetype/node.py)
+    * This archetype is currently the same as the docker archetype, but it uses the package.json for versioning. It also depends on a Dockerfile.
+    

--- a/mule/ci/README.md
+++ b/mule/ci/README.md
@@ -6,7 +6,21 @@ This package is for code related to the muleci project.
 Archetypes are generic pipeline implementations for different stacks. They all implement [IArchetype](archetype/__init__.py) so that muleci knows how to perform pipeline operations. When implementing an archetype, you have the option to implement each action supported by the muleci cli (build, publish, deploy, etc)
 
 * [docker](archetype/docker.py)
-    * Used to generically build/publish/deploy any project with a Dockerfile in the root directory. It uses git commit hashes for versioning.
+  * Used to generically build/publish/deploy any project with a Dockerfile in the root directory. It uses git commit hashes for versioning.
+  * actions
+    * deps
+      * Installs the awscli and helm
+    * build
+      * builds docker image
+    * publish
+      * Ensures that there is an appropriate ECR repository, and pushes the built docker image there
+    * deploy
+      * Uses the [rest-api](../util/resources/charts/rest-api) helm chart to deploy the app to kubernetes. It uses either the currently configured k8s cluster, or will deployed to an eks cluster specified with `EKS_CLUSTER_NAME`.
+    * undeploy
+      * Deletes the specified helm release for this application.
 * [npm](archetype/node.py)
-    * This archetype is currently the same as the docker archetype, but it uses the package.json for versioning. It also depends on a Dockerfile.
+  * This archetype is currently the same as the docker archetype, but it uses the package.json for versioning. It also depends on a Dockerfile.
+  * actions
+    * same as docker
+
     

--- a/mule/ci/archetype/docker.py
+++ b/mule/ci/archetype/docker.py
@@ -1,0 +1,45 @@
+from mule.ci.archetype import IArchetype
+from mule.ci import config
+from mule.util import git_util, docker_util, aws_util, helm_util
+
+
+class Docker(IArchetype):
+
+    def deps(self):
+        aws_util.deps()
+        helm_util.deps()
+        docker_util.deps()
+        npm_util.deps()
+
+    def build(self):
+        version = git_util.getHeadCommitHash()
+        docker_util.build([f"{self.application_name}:{version}"])
+
+    def publish(self, environment):
+        version = git_util.getHeadCommitHash()
+        repository = aws_util.ensure_repository(self.application_name, environment)
+
+        aws_util.ecr_login()
+        repository_uri = repository['repositoryUri']
+        source_image = f"{self.application_name}:{version}"
+        docker_util.tag(source_image, f"{repository_uri}:{version}")
+        docker_util.tag(source_image, f"{repository_uri}:latest")
+
+        docker_util.push([
+            f"{repository_uri}:{version}",
+            f"{repository_uri}:latest",
+        ])
+
+    def deploy(self, environment: str):
+        version = git_util.getHeadCommitHash()
+        if config.EKS_CLUSTER_NAME:
+            aws_util.update_kubeconfig(config.EKS_CLUSTER_NAME)
+        chart_path = helm_util.get_packaged_chart('rest-api')
+        helm_util.deploy(self.application_name, environment, version, chart_path)
+
+    def undeploy(self, environment: str):
+        version = git_util.getHeadCommitHash()
+        if config.EKS_CLUSTER_NAME:
+            aws_util.update_kubeconfig(config.EKS_CLUSTER_NAME)
+        chart_path = helm_util.get_packaged_chart('rest-api')
+        helm_util.delete(self.application_name, environment, version, chart_path)

--- a/mule/ci/archetype/docker.py
+++ b/mule/ci/archetype/docker.py
@@ -9,7 +9,6 @@ class Docker(IArchetype):
         aws_util.deps()
         helm_util.deps()
         docker_util.deps()
-        npm_util.deps()
 
     def build(self):
         version = git_util.getHeadCommitHash()

--- a/mule/ci/archetype/util.py
+++ b/mule/ci/archetype/util.py
@@ -1,9 +1,11 @@
 from pydoc import locate
 
 from mule.ci.archetype.node import Npm
+from mule.ci.archetype.docker import Docker
 
 archetypes = {
-    'npm': Npm
+    'npm': Npm,
+    'docker': Docker,
 }
 
 

--- a/mule/util/git_util.py
+++ b/mule/util/git_util.py
@@ -1,14 +1,13 @@
 import os
 import git
 
+cwd = os.getcwd()
+repo = git.Repo(cwd, search_parent_directories=True)
+
 def getLastTag():
-    cwd = os.getcwd()
-    repo = git.Repo(cwd)
     return repo.tags[-1]
 
 def getCommitsSinceTag(tag):
-    cwd = os.getcwd()
-    repo = git.Repo(cwd)
     return repo.iter_commits(rev=f"{tag}..HEAD")
 
 def getCommitsSinceLastTag():
@@ -16,6 +15,4 @@ def getCommitsSinceLastTag():
     return getCommitsSinceTag(last_tag)
 
 def getHeadCommitHash():
-    cwd = os.getcwd()
-    repo = git.Repo(cwd)
     return repo.head.object.hexsha


### PR DESCRIPTION
This is basically a copy of the npm archetype, but using git hashes for versioning. This allows the archetype to just generally build/deploy any dockerfile without dependencies on npm